### PR TITLE
chore(console): fix clippy warning

### DIFF
--- a/tokio-console/src/view/mod.rs
+++ b/tokio-console/src/view/mod.rs
@@ -70,6 +70,7 @@ pub(crate) enum UpdateKind {
     /// The TaskView is exited
     ExitTaskView,
     /// A new resource is selected
+    #[allow(dead_code)]
     SelectResource(u64),
     /// No significant change
     Other,


### PR DESCRIPTION
This is copying how this issue was fixed in the real console.