### PR TITLE
chore: automate releases with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,11 @@
+[workspace]
+changelog_config = "cliff.toml"
+
+[[package]]
+name = "console-api"
+
+[[package]]
+name = "console-subscriber"
+
+[[package]]
+name = "tokio-console"


### PR DESCRIPTION
This change uses the `release-plz` action to automate releases.

Clearly this is testing for now.