### PR TITLE
feat(api): add another field to task update

### DIFF
--- a/console-api/proto/tasks.proto
+++ b/console-api/proto/tasks.proto
@@ -37,6 +37,8 @@ message TaskUpdate {
     // If the application's instrumentation ensures reliable delivery of events,
     // this will always be 0.
     uint64 dropped_events = 4;
+    // Another field.
+    uint64 another_field = 5;
 }
 
 // A task details update

--- a/console-api/src/generated/rs.tokio.console.tasks.rs
+++ b/console-api/src/generated/rs.tokio.console.tasks.rs
@@ -34,6 +34,9 @@ pub struct TaskUpdate {
     /// this will always be 0.
     #[prost(uint64, tag = "4")]
     pub dropped_events: u64,
+    /// Another field.
+    #[prost(uint64, tag = "5")]
+    pub another_field: u64,
 }
 /// A task details update
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/console-subscriber/examples/grpc_web/app/src/gen/tasks_pb.ts
+++ b/console-subscriber/examples/grpc_web/app/src/gen/tasks_pb.ts
@@ -57,6 +57,13 @@ export class TaskUpdate extends Message<TaskUpdate> {
    */
   droppedEvents = protoInt64.zero;
 
+  /**
+   * Another field.
+   *
+   * @generated from field: uint64 another_field = 5;
+   */
+  anotherField = protoInt64.zero;
+
   constructor(data?: PartialMessage<TaskUpdate>) {
     super();
     proto3.util.initPartial(data, this);
@@ -68,6 +75,7 @@ export class TaskUpdate extends Message<TaskUpdate> {
     { no: 1, name: "new_tasks", kind: "message", T: Task, repeated: true },
     { no: 3, name: "stats_update", kind: "map", K: 4 /* ScalarType.UINT64 */, V: {kind: "message", T: Stats} },
     { no: 4, name: "dropped_events", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
+    { no: 5, name: "another_field", kind: "scalar", T: 4 /* ScalarType.UINT64 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): TaskUpdate {

--- a/console-subscriber/src/aggregator/mod.rs
+++ b/console-subscriber/src/aggregator/mod.rs
@@ -340,6 +340,7 @@ impl Aggregator {
             new_tasks: self.tasks.as_proto_list(include, &self.base_time),
             stats_update: self.task_stats.as_proto(include, &self.base_time),
             dropped_events: self.shared.dropped_tasks.swap(0, AcqRel) as u64,
+            another_field: 0,
         }
     }
 


### PR DESCRIPTION
This is a new field in an all pub struct (which could therefore be
constructed directly). This probably needs to be a breaking change.

BREAKING CHANGE: The new field in the `TaskUpdate` struct constitutes a
breaking change.